### PR TITLE
Migrate to Spring Boot 3.2.4

### DIFF
--- a/examples/backend/java/spring-boot/spring-boot-2-gradle-upgrade/build.gradle
+++ b/examples/backend/java/spring-boot/spring-boot-2-gradle-upgrade/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.JavaVersion
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.18'
+    id 'org.springframework.boot' version '3.2.4'\n    id 'io.spring.dependency-management' version '1.1.4'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
@@ -15,7 +15,7 @@ java {
 
 repositories {
     mavenCentral()
-}
+}\n\njava {\n    sourceCompatibility = JavaVersion.VERSION_17\n    targetCompatibility = JavaVersion.VERSION_17\n}
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/examples/backend/java/spring-boot/spring-boot-2-gradle-upgrade/src/main/java/com/sourcegraph/demo/config/SecurityConfig.java
+++ b/examples/backend/java/spring-boot/spring-boot-2-gradle-upgrade/src/main/java/com/sourcegraph/demo/config/SecurityConfig.java
@@ -7,7 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig  {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/examples/backend/java/spring-boot/spring-boot-2-gradle-upgrade/src/main/java/com/sourcegraph/demo/entity/Product.java
+++ b/examples/backend/java/spring-boot/spring-boot-2-gradle-upgrade/src/main/java/com/sourcegraph/demo/entity/Product.java
@@ -1,9 +1,9 @@
 package com.sourcegraph.demo.entity;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 
 @Entity
 public class Product {

--- a/examples/cli/java/excel-reader/build.gradle
+++ b/examples/cli/java/excel-reader/build.gradle
@@ -11,7 +11,7 @@ targetCompatibility = 17
 
 repositories {
     mavenCentral()
-}
+}\n\njava {\n    sourceCompatibility = JavaVersion.VERSION_17\n    targetCompatibility = JavaVersion.VERSION_17\n}
 
 dependencies {
     // Apache POI for Excel file handling


### PR DESCRIPTION
# Spring Boot 3.2.4 Migration

This automated migration includes:

* Updated Java requirement to Java 17
* Updated Gradle wrapper to 8.7
* Updated Spring Boot to 3.2.4
* Migrated javax packages to jakarta
* Updated deprecated security configurations

## Manual verification needed

After applying these changes, please:
1. Verify all tests pass
2. Check for any remaining javax imports that might need manual migration
3. Review security configuration changes

[_Created by Sourcegraph batch change `travis.lyons/spring-boot-2-to-3`._](https://demo.sourcegraph.com/users/travis.lyons/batch-changes/spring-boot-2-to-3)